### PR TITLE
Change name of interpolate command to simulate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To set up the project locally, follow these steps:
 
 1. Install the repository from github:
     ```bash
-    pip install git+https://github.com/Gersbachlab-Bioinformatics/FRACTEL
+    pip install --force --no-deps git+https://github.com/Gersbachlab-Bioinformatics/FRACTEL
     ```
 
 ## Usage
@@ -24,14 +24,15 @@ usage: fractel.py [-h] {run,simulate,interpolate} ...
 FRACTEL: Framework for Rank Aggregation of CRISPR Tests within ELements
 
 positional arguments:
-  {run,simulate,interpolate}
+  {run,simulate,calibrate}
                         Sub-command to execute
     run                 Run FRACTEL test on a given dataframe with p-values of grouped elements
     simulate            Simulate data for FRACTEL analysis
-    interpolate         Interpolate p-values in a data frame based on a reference data frame
+    calibrate           Calibrate p-values in a data frame based on a background distribution. Currently, the calibration is done by adjusting an empirical cumulative
+                        distribution function (ECDF) from the background/reference set and evaluating the observed p-values against it.
 
 options:
-  -h, --help      show this help message and exit
+  -h, --help            show this help message and exit
 ```
 
 ## Contributing

--- a/fractel/fractel.py
+++ b/fractel/fractel.py
@@ -241,7 +241,7 @@ def save_df_to_tsv(df, output_basename, keep_index=False):
     df.to_csv(f'{output_basename}.tsv.gz', sep='\t', index = keep_index, compression='gzip')
     print(f"Results saved to {output_basename}.tsv.gz")
 
-def run_interpolate(args):
+def run_calibration(args):
     """
     Interpolate p-values in a data frame based on a reference data frame and save the result.
     """
@@ -470,20 +470,22 @@ def main():
     simulate_parser.add_argument('--bnd-min', type=int, default = 3,
                                  help='Minimum number of singletons for the simulation, in case using a variable/proportional bound (default: %(default)s)')
 
-    interpolate_parser = subparsers.add_parser(
-        'interpolate',
-        help='Interpolate p-values in a data frame based on a reference data frame'
+    calibrate_parser = subparsers.add_parser(
+        'calibrate',
+        help='''Calibrate p-values in a data frame based on a background distribution. Currently, the calibration 
+        is done by adjusting an empirical cumulative distribution function (ECDF) from the background/reference set 
+        and evaluating the observed p-values against it.'''
     )
-    interpolate_parser.add_argument('--data-frame', required=True, type=str,
-                                    help='File path to the data frame with p-values to interpolate')
-    interpolate_parser.add_argument('--pval-col', default='pvalue', type=str,
+    calibrate_parser.add_argument('--data-frame', required=True, type=str,
+                                    help='File path to the data frame with background p-values (e.g. non-targeting control p-values)')
+    calibrate_parser.add_argument('--pval-col', default='pvalue', type=str,
                                     help='Column name in the data frames with the p-values to interpolate (default: %(default)s)')
-    interpolate_parser.add_argument('--interpolated-col', default='interpolated_pvalue', type=str,
+    calibrate_parser.add_argument('--interpolated-col', default='interpolated_pvalue', type=str,
                                     help='Column name for the interpolated p-values (default: %(default)s)')
-    interpolate_parser.add_argument('--output-basename', required=True, type=str,
+    calibrate_parser.add_argument('--output-basename', required=True, type=str,
                                     help='Base name for the output file to save the results (will be saved as a compressed tsv file)')
     # Group the reference dataframe selection arguments
-    reference_df_select_group = interpolate_parser.add_argument_group('reference dataframe')
+    reference_df_select_group = calibrate_parser.add_argument_group('reference dataframe')
     reference_df_select_group.add_argument('--reference-data-frame', required=True, type=str,
                                            help='File path to the reference data frame with p-values')
     reference_df_select_group.add_argument('--reference-df-select-col', type=str,
@@ -514,8 +516,8 @@ def main():
         case 'simulate':
             sim_dict = run_simulation(args)
             save_simulation_data(sim_dict, args.output_basename)
-        case 'interpolate':
-            df = run_interpolate(args)
+        case 'calibrate':
+            df = run_calibration(args)
             save_df_to_tsv(df, args.output_basename)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "fractel"
-version = "0.1.0"
+version = "0.1.1"
 description = "FRACTEL: Framework for Rank Aggregation of CRISPR Tests within ELements"
 readme = "README.md"
 authors = [

--- a/tests/test_fractel_calibrate.py
+++ b/tests/test_fractel_calibrate.py
@@ -3,11 +3,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from fractel.fractel import interpolate_pvalues, run_interpolate
+from fractel.fractel import interpolate_pvalues, run_calibration
 
 
 @pytest.fixture
-def interpolate_test_data():
+def calibrate_test_data():
     df = pd.DataFrame({
         "id": [1, 2, 3, 4, 5],
         "pvalue": [0.01, 0.2, 0.5, 0.8, 0.99]
@@ -19,36 +19,36 @@ def interpolate_test_data():
     })
     return df, reference_df
 
-def test_interpolate_pvalues_basic(interpolate_test_data):
-    df, reference_df = interpolate_test_data
+def test_calibrate_pvalues_basic(calibrate_test_data):
+    df, reference_df = calibrate_test_data
     result = interpolate_pvalues(df.copy(), reference_df, pval_col="pvalue", interpolated_col="interp")
     assert "interp" in result.columns
     assert np.all((result["interp"] >= 0) & (result["interp"] <= 1))
     assert len(result) == len(df)
 
-def test_interpolate_pvalues_with_different_col_names():
+def test_calibrate_pvalues_with_different_col_names():
     df = pd.DataFrame({"x": [0.1, 0.2, 0.3]})
     ref = pd.DataFrame({"x": [0.05, 0.15, 0.25, 0.35]})
     result = interpolate_pvalues(df.copy(), ref, pval_col="x", interpolated_col="y")
     assert "y" in result.columns
     assert np.all((result["y"] >= 0) & (result["y"] <= 1))
 
-def test_interpolate_pvalues_empty_df():
+def test_calibrate_pvalues_empty_df():
     df = pd.DataFrame(columns=["pvalue"])
     ref = pd.DataFrame({"pvalue": [0.1, 0.2, 0.3]})
     result = interpolate_pvalues(df.copy(), ref)
     assert "interpolated_pvalue" in result.columns
     assert result.empty
 
-def test_interpolate_pvalues_empty_reference():
+def test_calibrate_pvalues_empty_reference():
     df = pd.DataFrame({"pvalue": [0.1, 0.2, 0.3]})
     ref = pd.DataFrame(columns=["pvalue"])
     with pytest.raises(ValueError):
         interpolate_pvalues(df.copy(), ref)
 
 @pytest.fixture
-def interpolate_args(tmp_path, interpolate_test_data):
-    df, reference_df = interpolate_test_data
+def calibrate_args(tmp_path, calibrate_test_data):
+    df, reference_df = calibrate_test_data
     df_path = tmp_path / "df.tsv"
     ref_path = tmp_path / "ref.tsv"
     df.to_csv(df_path, sep="\t", index=False)
@@ -63,15 +63,15 @@ def interpolate_args(tmp_path, interpolate_test_data):
     args.reference_df_select_value = None
     return args, df, reference_df
 
-def test_run_interpolate_basic(interpolate_args):
-    args, df, reference_df = interpolate_args
-    result = run_interpolate(args)
+def test_run_calibrate_basic(calibrate_args):
+    args, df, reference_df = calibrate_args
+    result = run_calibration(args)
     assert "interp" in result.columns
     assert len(result) == len(df)
     assert np.all((result["interp"] >= 0) & (result["interp"] <= 1))
 
-def test_run_interpolate_with_reference_selection(tmp_path, interpolate_test_data):
-    df, reference_df = interpolate_test_data
+def test_run_calibrate_with_reference_selection(tmp_path, calibrate_test_data):
+    df, reference_df = calibrate_test_data
     df_path = tmp_path / "df.tsv"
     ref_path = tmp_path / "ref.tsv"
     df.to_csv(df_path, sep="\t", index=False)
@@ -84,13 +84,13 @@ def test_run_interpolate_with_reference_selection(tmp_path, interpolate_test_dat
     args.output_basename = str(tmp_path / "output")
     args.reference_df_select_col = "group"
     args.reference_df_select_value = "A"
-    result = run_interpolate(args)
+    result = run_calibration(args)
     assert "interp" in result.columns
     assert len(result) == len(df)
     assert np.all((result["interp"] >= 0) & (result["interp"] <= 1))
 
-def test_run_interpolate_with_reference_selection_no_rows(tmp_path, interpolate_test_data):
-    df, reference_df = interpolate_test_data
+def test_run_calibrate_with_reference_selection_no_rows(tmp_path, calibrate_test_data):
+    df, reference_df = calibrate_test_data
     df_path = tmp_path / "df.tsv"
     ref_path = tmp_path / "ref.tsv"
     df.to_csv(df_path, sep="\t", index=False)
@@ -104,5 +104,4 @@ def test_run_interpolate_with_reference_selection_no_rows(tmp_path, interpolate_
     args.reference_df_select_col = "group"
     args.reference_df_select_value = "Z"  # not present
     with pytest.raises(AssertionError):
-        run_interpolate(args)
-
+        run_calibration(args)


### PR DESCRIPTION
This change is mostly cosmetic, but might help in the long run since we apply this when the observed p-values are not correctly calibrated